### PR TITLE
Support the use of sprite sheets through sub-rectangle drawImage syntax

### DIFF
--- a/src/monet/canvas.cljs
+++ b/src/monet/canvas.cljs
@@ -147,6 +147,9 @@
      ctx)
   ([ctx img {:keys [x y w h]}]
      (. ctx (drawImage img x y w h))
+     ctx)
+  ([ctx img {:keys [sx sy sw sh dx dy dw dh]}]
+     (. ctx (drawImage img sx sy sw sh dx dy dw dh))
      ctx))
 
 (defn quadratic-curve-to 


### PR DESCRIPTION
- See https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D?redirectlocale=en-US&redirectslug=DOM%2FCanvasRenderingContext2D#drawImage() for parameters and documentation.

It was necessary to add this for my game, so I thought I would contribute it back. Certainly open to making the parameter names more readable if that is a concern.
